### PR TITLE
Fix typeform retrive

### DIFF
--- a/answers.php
+++ b/answers.php
@@ -1,0 +1,25 @@
+<?php
+    if( $_GET["email"] || $_GET["form_id"] || $_GET["key"]) {
+
+        if ($_GET["key"] !== "sK!RkF26bx9MkeRqcNkE@4aDV!BRi!") {
+            header('HTTP/1.0 401 Unauthorized');
+            echo 'Unauthorized';
+            exit();
+        }
+
+        $ch = curl_init();
+        if ($_GET["email"]) {
+            curl_setopt($ch, CURLOPT_URL,"https://api.typeform.com/forms/".$_GET["form_id"]."/responses?query=".$_GET["email"]);
+        } else {
+            curl_setopt($ch, CURLOPT_URL,"https://api.typeform.com/forms/".$_GET["form_id"]);
+        }
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ["authorization: bearer 9fAkEMopTf1VvZvCKUPpUnPpzNeZpVM7b8xt4xXpeoVu"]);
+        $server_output = curl_exec($ch);
+        curl_close($ch);
+
+        header('Content-type: application/json');
+        echo $server_output;
+        exit();
+    }
+?>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -144,63 +144,44 @@ function getParameterByName(name, url) {
     return decodeURIComponent(results[2].replace(/\+/g, " "));
 }
 
-function getSubmission(email) {
-  $.ajax({
-    url: "https://api.typeform.com/forms/fepjH3",
-    method: "GET",
-    crossDomain: true,
-    contentType: 'application/json',
-    dataType: 'jsonp',
-    headers: {
-        "Authorization" : "Bearer " + '9oQ6A1BHkvFioS9zJZf7rM9PKMbxhPjNmQ6NMTujVBiy',
-        'Access-Control-Allow-Origin': '*',
-        'Content-Type':'application/json'
-    },
-    success: function(response) {
-      console.log(response);
-        // var label;
-        // //console.log( response );
+function getSubmission(email, key) {
+  var form_id = "fepjH3" // Current main form id, change for each type
 
-        // // Parsing JSON for answer values by ID
-        // for(var n=0; n<questIDs.length; n++) {
-        //     for(var i=0; i<response.fields.length; i++) {
-        //         //console.log(response.items[0].answers[i].field.id);
-        //         if(response.fields[i].id == questIDs[n]){
-        //             label = response.fields[i].properties.description.substr(1).slice(0, -1);
-        //             //console.log(label);
-        //             $('.result-value[data-answer="'+(n+1)+'"]').prev('.result-text').find('h3').html(label);
-        //             //console.log($('.result-value[data-answer="'+(n+1)+'"]').prev('h3').html());
-        //         }
-        //     }
-        // }
+  // This request will fetch all form questions format
+  $.ajax({
+    url: "answers.php?&form_id=" + form_id + "&key=" + key,
+    method: "GET",
+    contentType: 'application/json',
+    success: function(response) {
+        var label;
+        // Parsing JSON for answer values by ID
+        for(var n=0; n<questIDs.length; n++) {
+            for(var i=0; i<response.fields.length; i++) {
+                if(response.fields[i].id == questIDs[n]){
+                    label = response.fields[i].properties.description.substr(1).slice(0, -1);
+                    $('.result-value[data-answer="'+(n+1)+'"]').prev('.result-text').find('h3').html(label);
+                }
+            }
+        }
     }
   });
 
+  // This request will fetch the answers associated to that email address
   $.ajax({
-      url: "https://api.typeform.com/forms/fepjH3/responses?query="+email,
+      url: "/answers.php?email=" + email + "&form_id=" + form_id + "&key=" + key,
       method: "GET",
-      headers: {
-          "Authorization" : "Bearer " + '9oQ6A1BHkvFioS9zJZf7rM9PKMbxhPjNmQ6NMTujVBiy'
-      },
       success: function(response) {
-          //var ids = [];
-          console.log( response );
-
           // Parsing JSON for answer values by ID
-          // for(var n=0; n<questIDs.length; n++) {
-          //     for(var i=0; i<response.items[0].answers.length; i++) {
-          //         //console.log(response.items[0].answers[i].field.id);
-          //         if(response.items[0].answers[i].field.id == questIDs[n]){
-          //             answers[n] = response.items[0].answers[i].choice.label;
-          //         }
-          //     }
-          // }
-
-          // //console.log( answers );
-          // answers = extractValues(answers);
-          // //console.log( response.items[0].answers );
-          // mainChart(answers);
-          // singleCharts(answers);
+          for(var n=0; n<questIDs.length; n++) {
+              for(var i=0; i<response.items[0].answers.length; i++) {
+                  if(response.items[0].answers[i].field.id == questIDs[n]){
+                      answers[n] = response.items[0].answers[i].choice.label;
+                  }
+              }
+          }
+          answers = extractValues(answers);
+          mainChart(answers);
+          singleCharts(answers);
       }
   });
 }
@@ -214,8 +195,9 @@ function getSubmission(email) {
 // });
 
 var userEmail = getParameterByName('email');
-if(userEmail){
-    getSubmission(userEmail);
+var key = getParameterByName('key');
+if(userEmail && key){
+    getSubmission(userEmail, key);
 }
 
 // mainChart(exResponses);


### PR DESCRIPTION
Para arreglar la situación actual he creado el fichero "answers.php", este devuelve lo mismo que Typeform, por lo que el documente sigue funcionando como antes. El problema surgía que Typeform ya no deja solicitar su API desde clientes en el navegador y tiene que ser el servidor.

Para poner una capa mínima de seguridad en la dirección de vuelta del formulario a parte de el correo también tendremos que poner la key que el cliente usara para identificarse con nuestro servidor. `/?email=[user_email]&key=sK!RkF26bx9MkeRqcNkE@4aDV!BRi!`

Como hemos comentado por correo solo he modificado el principal, el resto los vais a modificar vosotros.